### PR TITLE
🐛 Update Webpack Config SCSS Rules

### DIFF
--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -1,6 +1,6 @@
-@use 'foundation/variables';
-@use 'foundation/mixins';
+@import './foundation/_variables';
+@import './foundation/_mixins';
 
 body {
-	color: $body-color;
+  color: $body-color;
 }

--- a/webpack.js
+++ b/webpack.js
@@ -1,6 +1,6 @@
-const autoprefixer = require('autoprefixer')
-const { CleanWebpackPlugin } = require('clean-webpack-plugin')
-const cssnano = require('cssnano')
+const autoprefixer = require('autoprefixer');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const cssnano = require('cssnano');
 const Dotenv = require('dotenv-webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -10,7 +10,7 @@ const webpack = require('webpack');
 require('dotenv').config();
 
 const devMode = process.env.NODE_ENV !== 'production';
-console.log(devMode)
+console.log(devMode);
 
 const buildDir = path.join(__dirname, 'build');
 
@@ -21,13 +21,13 @@ const plugins = [
     title: 'Production'
   })
 ];
-if(!devMode) {
+if (!devMode) {
   // Only enabled in production environment
   plugins.push(
     new MiniCssExtractPlugin({
       filename: '[name].[contenthash].css',
       chunkFilename: '[id].[contenthash].css'
-    }),
+    })
     // new webpack.DefinePlugin({
     //   'process.env': {
     //     'N4J_HOST': JSON.stringify(process.env.N4J_HOST),
@@ -35,32 +35,30 @@ if(!devMode) {
     //     'N4J_PASS': JSON.stringify(process.env.N4J_PASS)
     //   }
     // })
-  )
+  );
 } else {
-  plugins.push(
-    new Dotenv()
-  )
+  plugins.push(new Dotenv());
 }
 
 module.exports = {
   mode: devMode ? 'development' : 'production',
   entry: {
     app: './src/app.js',
-    neo4j: './src/scripts/neo4j.js',
+    neo4j: './src/scripts/neo4j.js'
   },
   optimization: {
     splitChunks: {
-      chunks: 'all',
+      chunks: 'all'
     }
   },
   plugins,
   output: {
     filename: '[name].bundle.js',
-    path: buildDir,
+    path: buildDir
   },
   devtool: 'inline-source-map',
   devServer: {
-    contentBase: buildDir,
+    contentBase: buildDir
   },
   stats: {
     colors: true,
@@ -68,26 +66,40 @@ module.exports = {
   },
   module: {
     rules: [
+      // {
+      //   test: /\.(sa|sc|c)ss$/,
+      //   use: [
+      //     devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
+      //     { loader: 'css-loader', options: { url: false, importLoaders: 1 } },
+      //     {
+      //       loader: 'postcss-loader',
+      //       options: { plugins: [autoprefixer(), cssnano()] }
+      //     },
+      //     'sass-loader'
+      //   ]
+      // },
       {
-        test: /\.(sa|sc|c)ss$/,
+        test: /\.s[ac]ss$/i,
         use: [
-          devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
-          { loader: "css-loader", options: { url: false, importLoaders: 1 } },
-          { loader: 'postcss-loader', options: { plugins: [autoprefixer(), cssnano()] }},
-          'sass-loader',
-        ],
+          // Creates `style` nodes from JS strings
+          'style-loader',
+          // Translates CSS into CommonJS
+          'css-loader',
+          // Compiles Sass to CSS
+          'sass-loader'
+        ]
       },
       {
         test: /\.jpe?g$|\.ico$|\.gif$|\.png$|\.svg$|\.woff$|\.ttf$|\.wav$|\.mp3$/,
-        loader: 'file-loader?name=[name].[ext]'  // <-- retain original file name
-    }
+        loader: 'file-loader?name=[name].[ext]' // <-- retain original file name
+      }
     ]
   },
   resolve: {
     extensions: ['.webpack.js', '.web.js', '.js', '.jsx', '.scss'],
     alias: {
       // Provides ability to include node_modules with ~
-      '~': path.resolve(process.cwd(), 'src'),
-    },
+      '~': path.resolve(process.cwd(), 'src')
+    }
   }
 };


### PR DESCRIPTION
I was able to get the SCSS build to work by simplifying the config, which I found directly in the [Webpack docs](https://webpack.js.org/loaders/sass-loader/), and by correcting the paths in the main `styles.scss` file. I also switched the `@use` to `@import`, which for whatever reason appears to be necessary in this particular fix scenario. 